### PR TITLE
Add scrape-infinite-scroll materials to repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This is our most recent article, we hope that you'll enjoy it!
 - [Scraping User-Submitted Reviews from the Steam Store](articles/steam-scraper) - Walks through the process of building an advanced Scrapy spider for the purpose of scraping user reviews from the Steam Store.
 - [Using Firefox WebExtensions with Selenium](articles/firefox-extensions-with-selenium) - A guide to launching Firefox with extensions preloaded using Selenium.
 - [Using Google Chrome Extensions with Selenium](articles/chrome-extensions-with-selenium) - A simple guide to launching Google Chrome with extensions preloaded using Selenium.
+- [Using Puppeteer to Scrape Websites with Infinite Scrolling](https://intoli.com/blog/scrape-infinite-scroll/) - Learn how to scrape an infinitely scrolling data feed with a headless browser.
 - [Why I Still Don't Use Yarn](articles/node-package-manager-benchmarks) - Benchmarks `npm`, `pnpm`, and `yarn` for installation time and storage space given a few common project configurations.
 
 
@@ -50,4 +51,3 @@ These are articles where we don't have any supplementary materials available, bu
 - [Saving Images from a Headless Browser](https://intoli.com/blog/saving-images/) - Learn how to save any image from a headless browser in this Puppeteer tutorial.
 - [Terminal Recorders: A Comprehensive Guide](https://intoli.com/blog/terminal-recorders/) - An in-depth comparision of different methods to record animations of terminal sessions.
 - [Understanding Neural Network Weight Initialization](https://intoli.com/blog/neural-network-initialization/) - Explores the effects of neural network weight initialization strategies.
-- [Using Puppeteer to Scrape Websites with Infinite Scrolling](https://intoli.com/blog/scrape-infinite-scroll/) - Learn how to scrape an infinitely scrolling data feed with a headless browser.

--- a/articles/scrape-infinite-scroll/README.md
+++ b/articles/scrape-infinite-scroll/README.md
@@ -1,0 +1,25 @@
+# Using Puppeteer to Scrape Websites with Infinite Scrolling
+
+This directory is centered around [scrape-infinite-scroll.js](scrape-infinite-scroll.js), which uses Puppeteer to scrape infinite scroll items from a [demo page](https://intoli.com/blog/scrape-infinite-scroll/demo.html) set up for it.
+The script's implementation details are described in the [Using Puppeteer to Scrape Websites with Infinite Scrolling]() article published on the Intoli blog.
+Customizing the script should be straightfoward after this article.
+
+To run the script, you need to have [Node.js](https://nodejs.org/en/) installed, which you can do using [nvm](https://github.com/creationix/nvm).
+With that out of the way, download the contents of this directory to disk.
+
+```bash
+git clone https://github.com/Intoli/intoli-article-materials.git
+cd intoli-article-materials/articles/scrape-infinite-scroll
+```
+
+And then install Puppeteer with
+
+```bash
+npm install
+```
+
+Finally, run the script with
+
+```bash
+node scrape-infinite-scroll.js
+```

--- a/articles/scrape-infinite-scroll/README.md
+++ b/articles/scrape-infinite-scroll/README.md
@@ -1,8 +1,8 @@
 # Using Puppeteer to Scrape Websites with Infinite Scrolling
 
 This directory is centered around [scrape-infinite-scroll.js](scrape-infinite-scroll.js), which uses Puppeteer to scrape infinite scroll items from a [demo page](https://intoli.com/blog/scrape-infinite-scroll/demo.html) set up for it.
-The script's implementation details are described in the [Using Puppeteer to Scrape Websites with Infinite Scrolling]() article published on the Intoli blog.
-Customizing the script should be straightfoward after this article.
+The script's implementation details are described in the [Using Puppeteer to Scrape Websites with Infinite Scrolling](https://intoli.com/blog/scrape-infinite-scroll/) article published on the Intoli blog.
+Customizing the script should be straightfoward after reading this article.
 
 To run the script, you need to have [Node.js](https://nodejs.org/en/) installed, which you can do using [nvm](https://github.com/creationix/nvm).
 With that out of the way, download the contents of this directory to disk.

--- a/articles/scrape-infinite-scroll/package.json
+++ b/articles/scrape-infinite-scroll/package.json
@@ -5,7 +5,7 @@
   "main": "scrape-infinite-scroll.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Intoli/intoli-article-materials.git"
+    "url": "https://github.com/Intoli/intoli-article-materials.git"
   },
   "keywords": [
     "scraping",

--- a/articles/scrape-infinite-scroll/package.json
+++ b/articles/scrape-infinite-scroll/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "scrape-infinite-scroll",
+  "version": "1.0.0",
+  "description": "A script which uses Puppeteer to scrape pages with infinite scroll.",
+  "main": "scrape-infinite-scroll.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Intoli/intoli-article-materials.git"
+  },
+  "keywords": [
+    "scraping",
+    "javascript",
+    "puppeteer",
+    "headless",
+    "chrome"
+  ],
+  "author": "Andre Perunicic / Intoli, LLC",
+  "license": "BSD-2-Clause",
+  "bugs": {
+    "url": "https://github.com/Intoli/intoli-article-materials/issues"
+  },
+  "homepage": "https://intoli.com/blog/scrape-infinite-scroll/",
+  "dependencies": {
+    "puppeteer": "^1.0.0"
+  }
+}

--- a/articles/scrape-infinite-scroll/scrape-infinite-scroll.js
+++ b/articles/scrape-infinite-scroll/scrape-infinite-scroll.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const puppeteer = require('puppeteer');
+
+/**
+ * This function is injected into the page and used to scrape items from it.
+ */
+function extractItems() {
+  const extractedElements = document.querySelectorAll('#boxes > div.box');
+  const items = [];
+  for (let element of extractedElements) {
+    items.push(element.innerText);
+  }
+  return items;
+}
+
+/**
+ * Scrolls and extracts content from a page.
+ * @param {object} page - A loaded Puppeteer Page instance.
+ * @param {function} extractItems - Item extraction function that is injected into the page.
+ * @param {number} itemTargetConut - The target number of items to extract before stopping.
+ * @param {number} scrollDelay - The time (in milliseconds) to wait between scrolls.
+ */
+async function scrapeInfiniteScrollItems(page, extractItems, itemTargetCount, scrollDelay = 1000) {
+  let items = [];
+  try {
+    let previousHeight;
+    while (items.length < itemTargetCount) {
+      items = await page.evaluate(extractItems);
+      previousHeight = await page.evaluate('document.body.scrollHeight');
+      await page.evaluate('window.scrollTo(0, document.body.scrollHeight)');
+      await page.waitForFunction(`document.body.scrollHeight > ${previousHeight}`);
+      await page.waitFor(scrollDelay);
+    }
+  } catch(e) { }
+  return items;
+}
+
+(async () => {
+  // Set up browser and page.
+  const browser = await puppeteer.launch({
+    headless: false,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+  const page = await browser.newPage();
+  page.setViewport({ width: 1280, height: 926 });
+
+  // Navigate to the demo page.
+  await page.goto('https://intoli.com/blog/scrape-infinite-scroll/demo.html');
+
+  // Scroll and extract items from the page.
+  const items = await scrapeInfiniteScrollItems(page, extractItems, 100);
+
+  // Save extracted items to a file.
+  fs.writeFileSync('./items.txt', items.join('\n') + '\n');
+
+  // Close the browser.
+  await browser.close();
+})();


### PR DESCRIPTION
This PR adds the supporting materials for the [Using Puppeteer to Scrape Websites with Infinite Scrolling](https://intoli.com/blog/scrape-infinite-scroll/) article and updates the main README accordingly.
