### PR TITLE
Add the article materials for the sandbox breakout article

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ Additionally, you can watch or start this repository to be made aware of new upd
 
 This is our most recent article, we hope that you'll enjoy it!
 
-- [How F5Bot Slurps All of Reddit](https://intoli.com/blog/f5bot/) - A guest post in which the creator of F5Bot explains in detail how it works, and how it's able to scrape million of Reddit comments per day in real-time.
+- [Breaking Out of the Chrome/WebExtension Sandbox](articles/sandbox-breakout/) - Uses some JavaScript trickery to break out of browser extension context to directly modify webpage native properties.
 
 
 ## Articles
 
 - [Analyzing One Million robots.txt Files](articles/analyzing-one-million-robots-txt-files) - Explores downloading and analyzing the `robots.txt` files for the Alex top one million websites.
+- [Breaking Out of the Chrome/WebExtension Sandbox](articles/sandbox-breakout/) - Uses some JavaScript trickery to break out of browser extension context to directly modify webpage native properties.
 - [Email Spy](articles/email-spy) - An open source Chrome/Firefox Web Extension that lets you find contact emails for any domain with a single click.
 - [Extending CircleCI's API with a Custom Microservice on AWS Lambda](articles/circleci-artifacts) - Explains how to deploy a nodejs express app as a microservice on AWS Lambda.
 - [Fantasy Football for Hackers](articles/fantasy-football-for-hackers) - Scrapes Fantasy Football projections and uses them to simulate league dynamics and calculate baseline subtracted values for players to use as a draft strategy.

--- a/articles/sandbox-breakout/README.md
+++ b/articles/sandbox-breakout/README.md
@@ -1,0 +1,55 @@
+# Breaking Out of the Chrome/WebExtension Sandbox
+
+[Breaking Out of the Chrome/WebExtension Sandbox](https://intoli.com/blog/sandbox-breakout/) is a guide to breaking out of the content script context of a browser extension so that you can interact with the page context directly.
+There are three supplemental materials for the article that are included here:
+
+- [language-test.html](language-test.html) - A simple test page that populates a header element with the current value of `window.navigator`.
+- [extension/manifest.json](extension/manifest.json) - The manifest for the extension that overwrites the `window.navigator` property.
+- [extension/sandbox-breakout.js](extension/sandbox-breakout.js]) - The implementation of the code which breaks out of the sandbox and overwrites `window.navigator`.
+
+A Chrome browser instance can be launched to run the tests with the following command.
+
+```bash
+google-chrome --load-extension=./extension/ language-test.html
+```
+
+If the sandbox breakout works as expected, this should open a webpage that displays the text `xx-XX`.
+You can see the [original article](https://intoli.com/blog/sandbox-breakout/) for details about how things work.
+
+
+## The runInPageContext() Method
+
+This is defined in [extension/sandbox-breakout.js](extension/sandbox-breakout.js]), but the portion of code that you're most likely interested in is this.
+
+```javascript
+// Breaks out of the content script context by injecting a specially
+// constructed script tag and injecting it into the page.
+const runInPageContext = (method, ...args) => {
+  // The stringified method which will be parsed as a function object.
+  const stringifiedMethod = method instanceof Function
+    ? method.toString()
+    : `() => { ${method} }`;
+
+  // The stringified arguments for the method, reconstructed into a spread array.
+  const stringifiedArgs = `JSON.parse(${JSON.stringify(JSON.stringify(args))})`;
+
+  // The full content of the script tag.
+  const scriptContent = `
+    // Parse and run the method with its arguments.
+    (${stringifiedMethod})(...${stringifiedArgs});
+
+    // Remove the script element to cover our tracks.
+    document.currentScript.parentElement
+      .removeChild(document.currentScript);
+  `;
+
+  // Create a script tag and inject it into the document.
+  const scriptElement = document.createElement('script');
+  scriptElement.innerHTML = scriptContent;
+  document.documentElement.prepend(scriptElement);
+};
+```
+
+This function can be called from an extension's content script context in order to evaluate JavaScript code in the corresponding page context.
+The first argument can be either a string containing JavaScript code or a function object.
+If it is a function object, then any additional arguments will be passed to the function when it is evaluated.

--- a/articles/sandbox-breakout/extension/manifest.json
+++ b/articles/sandbox-breakout/extension/manifest.json
@@ -1,0 +1,17 @@
+{
+  "manifest_version": 2,
+  "name": "Content Script Sandbox Breakout Extension",
+  "version": "1.0.0",
+  "applications": {
+    "gecko": {
+      "id": "sandbox-breakout@intoli.com"
+    }
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["sandbox-breakout.js"],
+      "run_at": "document_start"
+    }
+  ]
+}

--- a/articles/sandbox-breakout/extension/sandbox-breakout.js
+++ b/articles/sandbox-breakout/extension/sandbox-breakout.js
@@ -1,0 +1,41 @@
+// Overwrite the `navigator.language` property to return a custom value.
+const overwriteLanguage = (language) => {
+  Object.defineProperty(navigator, 'language', {
+    get: () => language,
+  });
+};
+
+
+// Breaks out of the content script context by injecting a specially
+// constructed script tag and injecting it into the page.
+const runInPageContext = (method, ...args) => {
+  // The stringified method which will be parsed as a function object.
+  const stringifiedMethod = method instanceof Function
+    ? method.toString()
+    : `() => { ${method} }`;
+
+  // The stringified arguments for the method, reconstructed into a spread array.
+  const stringifiedArgs = `JSON.parse(${JSON.stringify(JSON.stringify(args))})`;
+
+  // The full content of the script tag.
+  const scriptContent = `
+    // Parse and run the method with its arguments.
+    (${stringifiedMethod})(...${stringifiedArgs});
+
+    // Remove the script element to cover our tracks.
+    document.currentScript.parentElement
+      .removeChild(document.currentScript);
+  `;
+
+  // Create a script tag and inject it into the document.
+  const scriptElement = document.createElement('script');
+  scriptElement.innerHTML = scriptContent;
+  document.documentElement.prepend(scriptElement);
+};
+
+
+// This won't work, it's sandboxed from the page context.
+overwriteLanguage('xx-XX');
+
+// This will work, it breaks out of the sandbox.
+runInPageContext(overwriteLanguage, 'xx-XX');

--- a/articles/sandbox-breakout/language-test.html
+++ b/articles/sandbox-breakout/language-test.html
@@ -1,0 +1,9 @@
+<html>
+  <body>
+    <h1 id="result">Please Wait...</h1>
+    <script type="text/javascript">
+      document.getElementById('result')
+        .innerHTML = navigator.language;
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This adds the supplementary materials for [Breaking Out of the Chrome/WebExtension Sandbox](https://intoli.com/blog/sandbox-breakout/) which is a guide to breaking out of the content script context of a browser extension so that you can interact with the page context directly.
